### PR TITLE
Minify CSS files for #26

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -11,14 +11,25 @@ module.exports = function(grunt) {
         }
       }
     },
+    cssmin: {
+      target: {
+        files: [{
+          expand: true,
+          cwd: 'open_notices/static/css/',
+          src: ['*.css', '!*.min.css'],
+          dest: 'open_notices/static/css/',
+          ext: '.min.css'
+        }]
+      }
+    },
     copy: {
       target: {
         files: [
           {
             expand: true,
             cwd: 'open_notices/assets/javascript',
-            src: ['*.js'], 
-            dest: 'open_notices/static/javascript', 
+            src: ['*.js'],
+            dest: 'open_notices/static/javascript',
             filter: 'isFile'
           }
         ]
@@ -27,7 +38,7 @@ module.exports = function(grunt) {
     watch: {
       css: {
         files: '**/*.scss',
-        tasks: ['sass']
+        tasks: ['sass', 'cssmin']
       },
       scripts: {
         files: 'open_notices/assets/**/*.js',
@@ -36,6 +47,7 @@ module.exports = function(grunt) {
     }
   });
   grunt.loadNpmTasks('grunt-contrib-sass');
+  grunt.loadNpmTasks('grunt-contrib-cssmin');
   grunt.loadNpmTasks('grunt-contrib-watch');
   grunt.loadNpmTasks('grunt-contrib-copy')
   grunt.registerTask('default',['watch']);

--- a/package.json
+++ b/package.json
@@ -3,8 +3,9 @@
   "version": "0.0.0",
   "devDependencies": {
     "grunt": "^1.0.1",
-    "grunt-contrib-sass": "^1.0.0",
     "grunt-contrib-copy": "^1.0.0",
+    "grunt-contrib-cssmin": "^1.0.2",
+    "grunt-contrib-sass": "^1.0.0",
     "grunt-contrib-uglify": "^2.0.0",
     "grunt-contrib-watch": "^1.0.0",
     "grunt-sass": "^1.2.1"


### PR DESCRIPTION
I've had a bash at tweaking the gruntfile to minify the CSS, which is my reading of #26. 

When you run this and update the scss files, if you're running `grunt watch` you should see some output like so:

```
~/C/m/open-notices ❯❯❯ grunt watch                                                                            ⏎ feature/minify-css ✱ ◼
Running "watch" task
Waiting...
>> File "open_notices/assets/scss/main.scss" changed.
Running "sass:dist" (sass) task

Running "cssmin:target" (cssmin) task
>> 1 file created. 139.67 kB → 62.41 kB

Done.
Completed in 6.566s at Sun Nov 27 2016 00:50:08 GMT+0100 (CET) - Waiting...
```